### PR TITLE
Add VMEM based GetSetter Parameter class(es)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,8 @@ pycsh_sources = [
 	'src/parameter/parameterarray.c',
 	'src/parameter/pythonparameter.c',
 	'src/parameter/pythonarrayparameter.c',
+	'src/parameter/pythongetsetparameter.c',
+	'src/parameter/pythongetsetarrayparameter.c',
 	'src/parameter/parameterlist.c',
 
 	# Wrapper functions

--- a/pycsh.pyi
+++ b/pycsh.pyi
@@ -313,6 +313,17 @@ class PythonParameter(Parameter):
 class PythonArrayParameter(PythonParameter, ParameterArray):
     """ ParameterArray created in Python. """
 
+class PythonGetSetParameter(PythonParameter):
+    """ ParameterArray created in Python. """
+
+    def __new__(cls, id: int, name: str, type: int, mask: int | str, unit: str = None, docstr: str = None, array_size: int = 0,
+                   callback: _Callable[[Parameter, int], None] = None, host: int = None, timeout: int = None,
+                   retries: int = 0, paramver: int = 2, getter: _Callable = None, setter: _Callable = None) -> PythonGetSetParameter:
+        """  """
+
+class PythonGetSetArrayParameter(PythonGetSetParameter, PythonArrayParameter):
+    """ ParameterArray created in Python. """
+
 # PyCharm may refuse to acknowledge that a list subclass is iterable, so we explicitly state that it is.
 class ParameterList(_pylist[Parameter | ParameterArray], _Iterable):
     """

--- a/src/parameter/pythongetsetarrayparameter.c
+++ b/src/parameter/pythongetsetarrayparameter.c
@@ -1,0 +1,41 @@
+
+#include "pythongetsetarrayparameter.h"
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "../utils.h"
+#include "pythongetsetparameter.h"
+#include "pythonarrayparameter.h"
+
+PyTypeObject * PythonGetSetArrayParameterType;
+
+// TODO Kevin: Ideally, PythonArrayParameterType.tp_dealloc (and its base classes) would call super, rather than providing a complete implementation themselves.
+
+/* TODO Kevin: Consider if this function could be called with __attribute__((constructor())),
+    we just need to ensure Python has been initialized beforehand. */
+PyTypeObject * create_pythongetsetarrayparameter_type(void) {
+
+    // Dynamically create the PythonArrayParameter type with multiple inheritance
+    PyObject *bases AUTO_DECREF = PyTuple_Pack(2, (PyObject *)&PythonGetSetParameterType, (PyObject *)&PythonArrayParameterType);
+    if (bases == NULL) {
+        return NULL;  
+    }
+    
+    PyObject *dict AUTO_DECREF = PyDict_New();
+    if (dict == NULL) {
+        return NULL;
+    }
+
+    PyObject *name AUTO_DECREF = PyUnicode_FromString("PythonGetSetArrayParameter");
+    if (name == NULL) {
+        return NULL;  
+    }
+
+    PythonGetSetArrayParameterType = (PyTypeObject*)PyObject_CallFunctionObjArgs((PyObject *)&PyType_Type, name, bases, dict, NULL);
+    if (PythonGetSetArrayParameterType == NULL) {
+        return NULL;  
+    }
+
+    return PythonGetSetArrayParameterType;
+}

--- a/src/parameter/pythongetsetarrayparameter.c
+++ b/src/parameter/pythongetsetarrayparameter.c
@@ -17,7 +17,7 @@ PyTypeObject * PythonGetSetArrayParameterType;
 PyTypeObject * create_pythongetsetarrayparameter_type(void) {
 
     // Dynamically create the PythonArrayParameter type with multiple inheritance
-    PyObject *bases AUTO_DECREF = PyTuple_Pack(2, (PyObject *)&PythonGetSetParameterType, (PyObject *)&PythonArrayParameterType);
+    PyObject *bases AUTO_DECREF = PyTuple_Pack(2, (PyObject *)&PythonGetSetParameterType, (PyObject *)PythonArrayParameterType);
     if (bases == NULL) {
         return NULL;  
     }

--- a/src/parameter/pythongetsetarrayparameter.h
+++ b/src/parameter/pythongetsetarrayparameter.h
@@ -1,0 +1,15 @@
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "pythongetsetparameter.h"
+
+typedef struct {
+    PythonGetSetParameterObject python_getset_parameter;
+    // No need to include ParameterArrayObject explicitly
+    // since it only adds ParameterObject which is already in PythonParameterObject
+} PythonGetSetArrayParameterObject;
+
+PyTypeObject * create_pythongetsetarrayparameter_type(void);
+
+extern PyTypeObject * PythonGetSetArrayParameterType;

--- a/src/parameter/pythongetsetparameter.c
+++ b/src/parameter/pythongetsetparameter.c
@@ -21,33 +21,33 @@ static PyObject *_pycsh_val_to_pyobject(param_type_e type, const void * value) {
     switch (type) {
 		case PARAM_TYPE_UINT8:
 		case PARAM_TYPE_XINT8:
-			return Py_BuildValue("B", value);
+			return Py_BuildValue("B", *(uint8_t*)value);
 		case PARAM_TYPE_UINT16:
 		case PARAM_TYPE_XINT16:
-			return Py_BuildValue("H", value);
+			return Py_BuildValue("H", *(uint16_t*)value);
 		case PARAM_TYPE_UINT32:
 		case PARAM_TYPE_XINT32:
-			return Py_BuildValue("I", value);
+			return Py_BuildValue("I", *(uint32_t*)value);
 		case PARAM_TYPE_UINT64:
 		case PARAM_TYPE_XINT64:
-			return Py_BuildValue("K", value);
+			return Py_BuildValue("K", *(uint64_t*)value);
 		case PARAM_TYPE_INT8:
-			return Py_BuildValue("b", value);
+			return Py_BuildValue("b", *(int8_t*)value);
 		case PARAM_TYPE_INT16:
-			return Py_BuildValue("h", value);
+			return Py_BuildValue("h", *(int16_t*)value);
 		case PARAM_TYPE_INT32:
-			return Py_BuildValue("i", value);
+			return Py_BuildValue("i", *(int32_t*)value);
 		case PARAM_TYPE_INT64:
-			return Py_BuildValue("k", value);
+			return Py_BuildValue("k", *(int64_t*)value);
 		case PARAM_TYPE_FLOAT:
-			return Py_BuildValue("f", value);
+			return Py_BuildValue("f", *(float*)value);
 		case PARAM_TYPE_DOUBLE:
-			return Py_BuildValue("d", value);
+			return Py_BuildValue("d", *(double*)value);
 		case PARAM_TYPE_STRING: {
-			return Py_BuildValue("s", value);
+			return Py_BuildValue("s", *(char*)value);
 		}
 		case PARAM_TYPE_DATA: {
-			return Py_BuildValue("O&", value);
+			return Py_BuildValue("O&", *(char*)value);
 		}
 		default: {
 			/* Default case to make the compiler happy. Set error and return */

--- a/src/parameter/pythongetsetparameter.c
+++ b/src/parameter/pythongetsetparameter.c
@@ -69,6 +69,10 @@ static PyObject *_pycsh_val_to_pyobject(param_type_e type, const void * value) {
  */
 static int _pycsh_param_pyval_to_cval(param_type_e type, PyObject * value_in, void * dataout, size_t array_len) {
 
+    if (value_in == NULL) {
+        return -6;
+    }
+
     /* Error check switch */
 	switch (type) {
 		case PARAM_TYPE_UINT8:
@@ -200,7 +204,7 @@ void Parameter_getter(vmem_t * vmem, uint32_t addr, void * dataout, uint32_t len
     /* Call the user Python getter */
     PyObject *value AUTO_DECREF = PyObject_CallObject(python_getter, args);
 
-    _pycsh_param_pyval_to_cval(param->type, value, dataout, param->array_size);
+    _pycsh_param_pyval_to_cval(param->type, value, dataout, param->array_size-offset);
 
 #if 0  // TODO Kevin: Either propagate exception naturally, or set FromCause to custom getter exception.
     if (PyErr_Occurred()) {

--- a/src/parameter/pythongetsetparameter.h
+++ b/src/parameter/pythongetsetparameter.h
@@ -1,0 +1,41 @@
+/*
+ * pythonparameter.h
+ *
+ * Contains the PythonParameter Parameter subclass.
+ *
+ */
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <param/param.h>
+
+#include "pythonparameter.h"
+
+/* TODO Kevin: If we wish to remain in line with PyExc_ParamCallbackError,
+    Getter/Setter exceptions should be created. */
+//extern PyObject * PyExc_ParamGetterError;
+//extern PyObject * PyExc_ParamSetterError;
+
+typedef struct {
+    PythonParameterObject parameter_object;
+    PyObject *getter_func;
+    PyObject *setter_func;
+
+    /* Every GetSetParameter instance allocates its own vmem.
+        This vmem is passed to its read/write,
+        which allows us to work our way back to the PythonGetSetParameterObject,
+        based on knowing the offset of the vmem field.
+        The PythonGetSetParameterObject is needed to call the Python getter/setter funcs. */
+    /* NOTE: PythonParameter (our baseclass) uses param_list_create_remote() to create its ->param,
+        which both allocates and assign a vmem to ->param->vmem.
+        This vmem will be overridden by the one you see below,
+        but it will still be freed by param_list_remove_specific().
+        It would be nice to reuse it,
+        but it probably can't help us find our PythonGetSetParameterObject */
+    vmem_t vmem_heap;  
+} PythonGetSetParameterObject;
+
+extern PyTypeObject PythonGetSetParameterType;

--- a/src/parameter/pythonparameter.h
+++ b/src/parameter/pythonparameter.h
@@ -10,6 +10,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include <stdbool.h>
 #include <param/param.h>
 
 #include "parameter.h"
@@ -29,4 +30,17 @@ extern PyTypeObject PythonParameterType;
 
 void Parameter_callback(param_t * param, int offset);
 
-int Parameter_set_callback(PythonParameterObject *self, PyObject *value, void *closure);
+PythonParameterObject * Parameter_create_new(PyTypeObject *type, uint16_t id, param_type_e param_type, uint32_t mask, char * name, char * unit, char * docstr, int array_size, const PyObject * callback, int host, int timeout, int retries, int paramver);
+
+// Source: https://chat.openai.com
+/**
+ * @brief Check that the callback accepts exactly one Parameter and one integer,
+ *  as specified by "void (*callback)(struct param_s * param, int offset)"
+ * 
+ * Currently also checks type-hints (if specified).
+ * 
+ * @param callback function to check
+ * @param raise_exc Whether to set exception message when returning false.
+ * @return true for success
+ */
+bool is_valid_callback(const PyObject *callback, bool raise_exc);

--- a/src/pycsh.c
+++ b/src/pycsh.c
@@ -56,6 +56,8 @@
 #include "parameter/parameterarray.h"
 #include "parameter/pythonparameter.h"
 #include "parameter/pythonarrayparameter.h"
+#include "parameter/pythongetsetparameter.h"
+#include "parameter/pythongetsetarrayparameter.h"
 #include "parameter/parameterlist.h"
 
 #include "slash_command/slash_command.h"
@@ -329,6 +331,16 @@ PyMODINIT_FUNC PyInit_pycsh(void) {
 	if (PyType_Ready(PythonArrayParameterType) < 0)
 		return NULL;
 
+	if (PyType_Ready(&PythonGetSetParameterType) < 0)
+        return NULL;
+
+	/* PythonArrayParameterType must be created dynamically after
+		ParameterArrayType and PythonParameterType to support multiple inheritance. */
+	if (create_pythongetsetarrayparameter_type() == NULL)
+		return NULL;
+	if (PyType_Ready(PythonGetSetArrayParameterType) < 0)
+		return NULL;
+
 	ParameterListType.tp_base = &PyList_Type;
 	if (PyType_Ready(&ParameterListType) < 0)
 		return NULL;
@@ -395,6 +407,20 @@ PyMODINIT_FUNC PyInit_pycsh(void) {
 	Py_INCREF(PythonArrayParameterType);
     if (PyModule_AddObject(m, "PythonArrayParameter", (PyObject *) PythonArrayParameterType) < 0) {
 		Py_DECREF(PythonArrayParameterType);
+        Py_DECREF(m);
+        return NULL;
+	}
+
+	Py_INCREF(&PythonGetSetParameterType);
+	if (PyModule_AddObject(m, "PythonGetSetParameter", (PyObject *) &PythonGetSetParameterType) < 0) {
+		Py_DECREF(&PythonGetSetParameterType);
+        Py_DECREF(m);
+        return NULL;
+	}
+
+	Py_INCREF(PythonGetSetArrayParameterType);
+    if (PyModule_AddObject(m, "PythonGetSetArrayParameter", (PyObject *) PythonGetSetArrayParameterType) < 0) {
+		Py_DECREF(PythonGetSetArrayParameterType);
         Py_DECREF(m);
         return NULL;
 	}


### PR DESCRIPTION
Currently PyCSH doesn't feature a wrapper class for vmem_t, but even if it will do so in the future, this GetSetter Parameter subclass will be quite a QoL boon to users that would otherwise need to create a loop for polling values.