### PR TITLE
Convenient wrapper class for 'ident' replies. Allows for easy iteration of multiple responses

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,8 @@ pycsh_sources = [
 	'src/parameter/pythongetsetparameter.c',
 	'src/parameter/pythongetsetarrayparameter.c',
 	'src/parameter/parameterlist.c',
+	'src/csp_classes/ident.c',
+	#'src/csp_classes/node.c',  # Coming soon...
 
 	# Wrapper functions
 	'src/wrapper/py_csp.c',

--- a/pycsh.pyi
+++ b/pycsh.pyi
@@ -15,6 +15,7 @@ from typing import \
     Iterable as _Iterable, \
     Literal as _Literal, \
     Callable as _Callable
+from datetime import datetime as _datetime
 
 _param_value_hint = int | float | str
 _param_type_hint = _param_value_hint | bytearray
@@ -429,6 +430,47 @@ class PythonSlashCommand(SlashCommand):
         """
 
 
+class Ident:
+    """
+    Convenient wrapper class for 'ident' replies. Allows for easy iteration of multiple responses:
+
+    for reply in Ident(16383):
+        print(f"{reply.hostname}@{reply.node}")
+    """
+
+    node: int
+    "Node of the 'module' that replied, which may differ from the targeted node in case of broadcast"
+    hostname: str
+    model: str
+    revision: str
+    "Revision of the 'module' that replied, which typically indicates software version"
+
+    # CSP doesn't seem to require these dates to be compilation dates,
+    # but they always seem to be so in practice.
+    date: str
+    "Typically compilation date, i.e: 'Jun 18 2024'"
+    time: str
+    "Typically compilation time, i.e: '14:06:09'"
+    datetime: _datetime
+    "Datetime object parsed from: Ident.date + Ident.time"
+
+    def __new__(cls, node: int = None, timeout: int = None, override: bool = False) -> tuple[Ident]:
+        """
+        Provide a node to 'ident' and receive an iterable of all replies.
+
+        :param node: Address of which to request identity, defaults to environment node.
+        :param timeout: Timeout in ms to wait for reply.
+        :param override: Whether to override the "known hosts" hostname of the responding module.
+
+        :raises RuntimeError: When called before .init().
+
+        :returns: A list of Ident instances based on replies to the specified node (which may be a broadcast)
+        """
+
+    def __str__(self) -> str:
+        """ Will return a string formatted as slash will print an ident reply """
+
+
 _param_ident_hint = int | str | Parameter  # Types accepted for finding a param_t
 
 
@@ -596,11 +638,11 @@ def ident(node: int = None, timeout: int = None, override: bool = False) -> str:
     """
     Print the identity of the specified node.
 
-    :param node: Address of subsystem.
+    :param node: Address of which to request identity, defaults to environment node.
     :param timeout: Timeout in ms to wait for reply.
+    :param override: Whether to override the "known hosts" hostname of the responding module.
 
     :raises RuntimeError: When called before .init().
-    :raises ConnectionError: When no response is received.
     """
 
 def reboot(node: int = None) -> None:

--- a/pycsh.pyi
+++ b/pycsh.pyi
@@ -452,7 +452,7 @@ class Ident:
     time: str
     "Typically compilation time, i.e: '14:06:09'"
     datetime: _datetime
-    "Datetime object parsed from: Ident.date + Ident.time"
+    "Datetime object constructed from: Ident.date + Ident.time"
 
     def __new__(cls, node: int = None, timeout: int = None, override: bool = False) -> tuple[Ident]:
         """

--- a/src/csp_classes/ident.c
+++ b/src/csp_classes/ident.c
@@ -1,0 +1,220 @@
+/*
+ * parameter.c
+ *
+ * Contains the Parameter base class.
+ *
+ *  Created on: Apr 28, 2022
+ *      Author: Kevin Wallentin Carlsen
+ */
+
+#include "ident.h"
+
+#include "structmember.h"
+
+#include <csp/csp_cmp.h>
+#include <csp/csp_types.h>
+
+#include "../pycsh.h"
+#include "../utils.h"
+#include "../csh/known_hosts.h"
+
+
+/* 1 for success. Compares the fields of two 'ident' replies, otherwise 0. Assumes self to be a IdentObject. */
+static int Ident_equal(PyObject *self, PyObject *other) {
+	if (PyObject_TypeCheck(other, &IdentType))
+		return PyObject_Hash(self) == PyObject_Hash(other);
+	return 0;
+}
+
+static PyObject * Ident_richcompare(PyObject *self, PyObject *other, int op) {
+
+	PyObject *result = Py_NotImplemented;
+
+	switch (op) {
+		// case Py_LT:
+		// 	break;
+		// case Py_LE:
+		// 	break;
+		case Py_EQ:
+			result = (Ident_equal(self, other)) ? Py_True : Py_False;
+			break;
+		case Py_NE:
+			result = (Ident_equal(self, other)) ? Py_False : Py_True;
+			break;
+		// case Py_GT:
+		// 	break;
+		// case Py_GE:
+		// 	break;
+	}
+
+    Py_XINCREF(result);
+    return result;
+}
+
+static PyObject * Ident_str(IdentObject *self) {
+	return PyUnicode_FromFormat("\nIDENT %hu\n  %s\n  %s\n  %s\n  %s %s\n", self->id.src, PyUnicode_AsUTF8(self->hostname), PyUnicode_AsUTF8(self->model), PyUnicode_AsUTF8(self->revision), PyUnicode_AsUTF8(self->date), PyUnicode_AsUTF8(self->time));
+}
+
+static void Ident_dealloc(IdentObject *self) {
+
+	Py_XDECREF(self->hostname);
+	Py_XDECREF(self->model);
+	Py_XDECREF(self->revision);
+	Py_XDECREF(self->date);
+	Py_XDECREF(self->time);
+	Py_XDECREF(self->datetime);
+
+	// Get the type of 'self' in case the user has subclassed 'Ident'.
+	Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+__attribute__((malloc, malloc(Ident_dealloc, 1)))
+static PyObject * Ident_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
+
+	static char *kwlist[] = {"node", "timeout", "override", NULL};
+
+	unsigned int node = pycsh_dfl_node;
+    unsigned int timeout = pycsh_dfl_timeout;
+    bool override = false;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|IIp", kwlist, &node, &timeout, &override)) {
+		return NULL;  // TypeError is thrown
+	}
+
+	struct csp_cmp_message msg;
+    msg.type = CSP_CMP_REQUEST;
+    msg.code = CSP_CMP_IDENT;
+    int size = sizeof(msg.type) + sizeof(msg.code) + sizeof(msg.ident);
+
+    csp_conn_t * conn;
+    csp_packet_t * packet;
+    Py_BEGIN_ALLOW_THREADS;
+    conn = csp_connect(CSP_PRIO_NORM, node, CSP_CMP, timeout, CSP_O_CRC32);
+    if (conn == NULL) {
+        return NULL;
+    }
+
+    packet = csp_buffer_get(size);
+    if (packet == NULL) {
+        csp_close(conn);
+        return NULL;
+    }
+
+    /* Copy the request */
+    memcpy(packet->data, &msg, size);
+    packet->length = size;
+
+    csp_send(conn, packet);
+    Py_END_ALLOW_THREADS;
+
+    PyObject * reply_tuple = PyTuple_New(0);
+
+	if (!reply_tuple) {
+		return NULL;  // Let's just assume that Python has set some a MemoryError exception here
+	}
+
+	// static void csp_buffer_cleanup(csp_packet_t ** packet) {
+	// 	csp_buffer_free(*packet);
+	// }
+
+    while((packet = csp_read(conn, timeout)) != NULL) {
+
+		// Using attribute, so we don't forget to free
+		// csp_packet_t *__packet __attribute__((cleanup(csp_buffer_cleanup))) = packet;
+
+        memcpy(&msg, packet->data, packet->length < size ? packet->length : size);
+		if (msg.code != CSP_CMP_IDENT) {
+			continue;
+		}
+
+		Py_ssize_t reply_index = PyTuple_GET_SIZE(reply_tuple);
+		/* Resize tuple to fit reply, this could probably be done more efficiently. */
+		if (_PyTuple_Resize(&reply_tuple, reply_index+1) < 0) {
+			// Handle tuple resizing failure
+			PyErr_SetString(PyExc_RuntimeError, "Failed to resize tuple for ident replies");
+			return NULL;
+		}
+
+		IdentObject *self = (IdentObject *)type->tp_alloc(type, 0);
+		if (self == NULL) {
+			/* This is likely a memory allocation error, in which case we expect .tp_alloc() to have raised an exception. */
+			return NULL;
+		}
+
+        memcpy(&self->id, &packet->id, sizeof(csp_id_t));
+
+		self->hostname = PyUnicode_FromStringAndSize(msg.ident.hostname, CSP_HOSTNAME_LEN);
+		self->model = PyUnicode_FromStringAndSize(msg.ident.model, CSP_MODEL_LEN);
+		self->revision = PyUnicode_FromStringAndSize(msg.ident.revision, CSP_CMP_IDENT_REV_LEN);
+		self->date = PyUnicode_FromStringAndSize(msg.ident.date, CSP_CMP_IDENT_DATE_LEN);
+		self->time = PyUnicode_FromStringAndSize(msg.ident.time, CSP_CMP_IDENT_TIME_LEN);
+
+		// TODO Kevin: Set self->datetime
+
+		if (!(self->hostname && self->model && self->revision && self->date && self->time)) {
+			PyErr_SetString(PyExc_MemoryError, "Failed to allocate memory for ident strings");
+			// TODO Kevin: Maybe we can return the objects we managed to create?
+			return NULL;
+		}
+
+		PyTuple_SET_ITEM(reply_tuple, reply_index, (PyObject*)self);
+
+		known_hosts_add(packet->id.src, msg.ident.hostname, override);
+    }
+
+    csp_close(conn);
+
+    return reply_tuple;
+}
+
+
+
+
+static long Ident_hash(IdentObject *self) {
+    return self->id.src + PyObject_Hash(self->hostname) + PyObject_Hash(self->model) + PyObject_Hash(self->revision) + PyObject_Hash(self->date) + PyObject_Hash(self->time);
+}
+
+#if 0
+static PyObject * Ident_get_name(IdentObject *self, void *closure) {
+	return Py_BuildValue("s", self->command->name);
+}
+
+static PyGetSetDef Ident_getsetters[] = {
+
+	{"name", (getter)Ident_get_name, NULL,
+     "Returns the name of the wrapped slash_command.", NULL},
+    {"args", (getter)Idents_get_args, NULL,
+     "The args string of the slash_command.", NULL},
+    {NULL, NULL, NULL, NULL}  /* Sentinel */
+};
+#endif
+
+static PyMemberDef Ident_members[] = {
+	/* Using T_OBJECT in case we decide to detect empty strings in the ident reply in the future.
+		We will then set the IdentObject fields to NULL/Py_None, so None can be returned to Python. */
+    {"node", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
+    {"hostname", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
+    {"model", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
+    {"revision", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
+    {"date", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
+    {"time", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
+    {"datetime", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
+    {NULL}  /* Sentinel */
+};
+
+PyTypeObject IdentType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "pycsh.Ident",
+    .tp_doc = "Convenient wrapper class for 'ident' replies. Allows for easy iteration of multiple responses",
+    .tp_basicsize = sizeof(IdentObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_new = Ident_new,
+    .tp_dealloc = (destructor)Ident_dealloc,
+	// .tp_getset = Ident_getsetters,
+	.tp_members = Ident_members,
+	// .tp_methods = Parameter_methods,
+	.tp_str = (reprfunc)Ident_str,
+	.tp_richcompare = (richcmpfunc)Ident_richcompare,
+	.tp_hash = (hashfunc)Ident_hash,
+};

--- a/src/csp_classes/ident.c
+++ b/src/csp_classes/ident.c
@@ -52,7 +52,15 @@ static PyObject * Ident_richcompare(PyObject *self, PyObject *other, int op) {
 }
 
 static PyObject * Ident_str(IdentObject *self) {
-	return PyUnicode_FromFormat("\nIDENT %hu\n  %s\n  %s\n  %s\n  %s %s\n", self->id.src, PyUnicode_AsUTF8(self->hostname), PyUnicode_AsUTF8(self->model), PyUnicode_AsUTF8(self->revision), PyUnicode_AsUTF8(self->date), PyUnicode_AsUTF8(self->time));
+	return PyUnicode_FromFormat(
+        "\nIDENT %d\n  %U\n  %U\n  %U\n  %U %U\n",
+        self->id.src,
+        self->hostname,
+        self->model,
+        self->revision,
+        self->date,
+        self->time
+    );
 }
 
 static void Ident_dealloc(IdentObject *self) {

--- a/src/csp_classes/ident.c
+++ b/src/csp_classes/ident.c
@@ -205,7 +205,7 @@ static PyObject * Ident_new(PyTypeObject *type, PyObject *args, PyObject *kwds) 
 				return NULL;
 			}
 
-			PyObject *datetime_obj AUTO_DECREF = PyObject_CallObject(datetime_strptime, datetime_args);
+			PyObject *datetime_obj = PyObject_CallObject(datetime_strptime, datetime_args);
 			if (!datetime_obj) {
 				return NULL;
 			}
@@ -227,32 +227,60 @@ static long Ident_hash(IdentObject *self) {
 }
 
 #if 0
-static PyObject * Ident_get_name(IdentObject *self, void *closure) {
-	return Py_BuildValue("s", self->command->name);
+static PyObject * Ident_get_node(IdentObject *self, void *closure) {
+	return Py_BuildValue("i", self->id.src);
+}
+
+static PyObject * Ident_get_hostname(IdentObject *self, void *closure) {
+	return Py_NewRef(self->hostname);
+}
+
+static PyObject * Ident_get_model(IdentObject *self, void *closure) {
+	return Py_NewRef(self->model);
+}
+
+static PyObject * Ident_get_revision(IdentObject *self, void *closure) {
+	return Py_NewRef(self->revision);
+}
+
+static PyObject * Ident_get_date(IdentObject *self, void *closure) {
+	return Py_NewRef(self->date);
+}
+
+static PyObject * Ident_get_time(IdentObject *self, void *closure) {
+	return Py_NewRef(self->time);
+}
+
+static PyObject * Ident_get_datetime(IdentObject *self, void *closure) {
+	return Py_NewRef(self->datetime);
 }
 
 static PyGetSetDef Ident_getsetters[] = {
 
-	{"name", (getter)Ident_get_name, NULL,
-     "Returns the name of the wrapped slash_command.", NULL},
-    {"args", (getter)Idents_get_args, NULL,
-     "The args string of the slash_command.", NULL},
+	{"node", (getter)Ident_get_node, NULL, "Returns the node of Ident reply", NULL},
+	{"hostname", (getter)Ident_get_hostname, NULL, "Returns the hostname of Ident reply", NULL},
+	{"model", (getter)Ident_get_model, NULL, "Returns the model of Ident reply", NULL},
+	{"revision", (getter)Ident_get_revision, NULL, "Returns the revision of Ident reply", NULL},
+	{"date", (getter)Ident_get_date, NULL, "Returns the date of Ident reply", NULL},
+	{"time", (getter)Ident_get_time, NULL, "Returns the time of Ident reply", NULL},
+	{"datetime", (getter)Ident_get_datetime, NULL, "Returns the datetime of Ident reply", NULL},
+	 
     {NULL, NULL, NULL, NULL}  /* Sentinel */
 };
-#endif
-
+#else
 static PyMemberDef Ident_members[] = {
 	/* Using T_OBJECT in case we decide to detect empty strings in the ident reply in the future.
 		We will then set the IdentObject fields to NULL/Py_None, so None can be returned to Python. */
-    {"node", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
-    {"hostname", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
-    {"model", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
-    {"revision", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
-    {"date", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
-    {"time", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
-    {"datetime", T_OBJECT, offsetof(IdentObject, id.src), READONLY},
+    {"node", T_USHORT, offsetof(IdentObject, id.src), READONLY, "Node of Ident reply"},
+    {"hostname", T_OBJECT, offsetof(IdentObject, hostname), READONLY, "Hostname of Ident reply"},
+    {"model", T_OBJECT, offsetof(IdentObject, model), READONLY, "Model of Ident reply"},
+    {"revision", T_OBJECT, offsetof(IdentObject, revision), READONLY, "Revision of Ident reply"},
+    {"date", T_OBJECT, offsetof(IdentObject, date), READONLY, "Date of Ident reply"},
+    {"time", T_OBJECT, offsetof(IdentObject, time), READONLY, "Time of Ident reply"},
+    {"datetime", T_OBJECT, offsetof(IdentObject, datetime), READONLY, "Datetime of Ident reply"},
     {NULL}  /* Sentinel */
 };
+#endif
 
 PyTypeObject IdentType = {
     PyVarObject_HEAD_INIT(NULL, 0)

--- a/src/csp_classes/ident.h
+++ b/src/csp_classes/ident.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <csp/csp_cmp.h>
+#include <csp/csp_types.h>
+
+
+typedef struct {
+    PyObject_HEAD
+
+    csp_id_t id;
+
+    // struct csp_cmp_message ident;
+    /* We would've had to to copy the strings in csp_cmp_message to reuse that struct.
+        So we might as well just store the string as PyObjects* instead. */
+    PyObject *hostname;
+    PyObject *model;
+    PyObject *revision;
+    PyObject *date;
+    PyObject *time;
+
+    PyObject *datetime;
+
+} IdentObject;
+
+extern PyTypeObject IdentType;

--- a/src/pycsh.c
+++ b/src/pycsh.c
@@ -60,6 +60,8 @@
 #include "parameter/pythongetsetarrayparameter.h"
 #include "parameter/parameterlist.h"
 
+#include "csp_classes/ident.h"
+
 #include "slash_command/slash_command.h"
 #include "slash_command/python_slash_command.h"
 
@@ -347,6 +349,10 @@ PyMODINIT_FUNC PyInit_pycsh(void) {
 		return NULL;
 
 
+	if (PyType_Ready(&IdentType) < 0)
+        return NULL;
+
+
 #ifdef PYCSH_HAVE_SLASH
 	if (PyType_Ready(&SlashCommandType) < 0)
         return NULL;
@@ -431,6 +437,14 @@ PyMODINIT_FUNC PyInit_pycsh(void) {
 		Py_DECREF(&ParameterListType);
 		Py_DECREF(m);
 		return NULL;
+	}
+
+
+	Py_INCREF(&IdentType);
+	if (PyModule_AddObject(m, "Ident", (PyObject *) &IdentType) < 0) {
+		Py_DECREF(&IdentType);
+        Py_DECREF(m);
+        return NULL;
 	}
 
 

--- a/src/slash_command/slash_command.c
+++ b/src/slash_command/slash_command.c
@@ -18,7 +18,7 @@
 #include "../utils.h"
 
 
-/* 1 for success. Compares the wrapped param_t for parameters, otherwise 0. Assumes self to be a SlashCommandObject. */
+/* 1 for success. Compares the wrapped slash_command (struct) between two SlashCommands, otherwise 0. Assumes self to be a SlashCommandObject. */
 static int SlashCommand_equal(PyObject *self, PyObject *other) {
 	if (PyObject_TypeCheck(other, &SlashCommandType))
 		return ((SlashCommandObject *)self)->command == ((SlashCommandObject *)other)->command;

--- a/src/wrapper/py_csp.c
+++ b/src/wrapper/py_csp.c
@@ -71,13 +71,13 @@ PyObject * pycsh_slash_ident(PyObject * self, PyObject * args, PyObject * kwds) 
     Py_BEGIN_ALLOW_THREADS;
     conn = csp_connect(CSP_PRIO_NORM, node, CSP_CMP, timeout, CSP_O_CRC32);
     if (conn == NULL) {
-        return 0;
+        return NULL;
     }
 
     packet = csp_buffer_get(size);
     if (packet == NULL) {
         csp_close(conn);
-        return 0;
+        return NULL;
     }
 
     /* Copy the request */


### PR DESCRIPTION
Add an "Ident" class, with fields as printed by the "ident" slash command.