### PR TITLE
Work on copy of command to avoid side effect from tokenization

### DIFF
--- a/src/wrapper/slash_py.c
+++ b/src/wrapper/slash_py.c
@@ -1,4 +1,5 @@
 #include "slash_py.h"
+#include <stdlib.h>
 #include <slash/slash.h>
 
 #define PY_SSIZE_T_CLEAN
@@ -26,5 +27,13 @@ PyObject * pycsh_slash_execute(PyObject * self, PyObject * args, PyObject * kwds
     char hist_buf[HISTORY_SIZE];
     slash_create_static(&slas, line_buf, LINE_SIZE, hist_buf, HISTORY_SIZE);
 
-    return Py_BuildValue("i", slash_execute(&slas, command));
+    size_t cmd_len = strlen(command);
+    char * cmd_cpy = malloc(cmd_len);
+    strncpy(cmd_cpy, command, cmd_len);
+
+    PyObject * ret = Py_BuildValue("i", slash_execute(&slas, cmd_cpy));
+
+    free(cmd_cpy);
+
+    return ret;
 }


### PR DESCRIPTION
Due to tokenization of the parsed command in `slash_execute`, the string gets mutated on execution. 

Example: 
```python
cmd = "node 12"
pycsh.slash_execute(cmd)
print(cmd.encode())
```
prints `b'node\x0012'` instead of the expected `b'node 12'`

This is resolved here by copying the command string before it is passed to the `slash_execute` C function. 